### PR TITLE
added new detections words to EN + update documentation for permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,8 @@ Say **“create a task”** or **“add a task”** → Your task goes straight 
 *[Video Demo 🎥](https://github.com/user-attachments/assets/c592b0e8-efc6-40d1-ad53-a442de69bfc5)*
 </div>
 
-
 > **⚠️ Important Notice (Breaking Changes):**
-> This version now uses Home Assistant's AI Task (`ai_task.generate_data`) pipeline instead of calling OpenAI directly.
-> After updating from a version before 2.0.0, you MUST reconfigure the integration and **select a compatible AI Task entity**.
-
+> Due to recent changes in Vikunja's API token permissions (starting from Vikunja 2.3.0), you will need to add the task update permission to your API token for the voice label attachment to work.
 
 ---
 
@@ -56,9 +53,7 @@ Say **“create a task”** or **“add a task”** → Your task goes straight 
      * **Set the following permissions**:
      * Labels: Create and Read All
      * Projects: Read All, Projectusers (optional - for user assignment)
-     * Tasks: Create
-
-       📹 [Video Guide](https://github.com/user-attachments/assets/8b68ab2a-2d8c-4dd4-881d-96ca2b501ddb)       
+     * Tasks: Create and Update
        
    * **AI Task entity** [Video Guide OpenRouter](https://github.com/user-attachments/assets/500ad67f-89a6-473b-a934-e08f7a35d7e7)
 

--- a/custom_components/vikunja_voice_assistant/api/vikunja_api.py
+++ b/custom_components/vikunja_voice_assistant/api/vikunja_api.py
@@ -14,6 +14,38 @@ class VikunjaAPI:
             "Authorization": f"Bearer {vikunja_api_key}",
         }
 
+    @staticmethod
+    def _log_response_content(err):
+        resp = getattr(err, "response", None)
+        if resp is not None and hasattr(resp, "text"):
+            _LOGGER.error("Response content: %s", resp.text)
+        return resp
+
+    @staticmethod
+    def _is_invalid_token_response(response) -> bool:
+        if response is None or getattr(response, "status_code", None) != 401:
+            return False
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = None
+        if isinstance(payload, dict):
+            if payload.get("code") == 11:
+                return True
+            message = str(payload.get("message", "")).lower()
+            return "invalid token" in message
+        text = getattr(response, "text", "")
+        return "invalid token" in text.lower()
+
+    def _log_scoped_token_hint(self, response, route_description, remedy):
+        if not self._is_invalid_token_response(response):
+            return
+        _LOGGER.error(
+            "Vikunja rejected %s with a route-specific token error. Scoped API tokens were tightened in Vikunja 2.3.0 and now match both HTTP method and path. %s",
+            route_description,
+            remedy,
+        )
+
     def test_connection(self):
         """Simple connectivity check by listing projects."""
         try:
@@ -114,9 +146,12 @@ class VikunjaAPI:
             _LOGGER.error(
                 "Failed to attach label %s to task %s: %s", label_id, task_id, err
             )
-            resp = getattr(err, "response", None)
-            if resp is not None and hasattr(resp, "text"):
-                _LOGGER.error("Response content: %s", resp.text)
+            resp = self._log_response_content(err)
+            self._log_scoped_token_hint(
+                resp,
+                "label attachment via PUT /tasks/{task}/labels",
+                "Recreate the API token and grant access for this route. For task labels, Vikunja usually needs task-update scope in addition to label read/create permissions. If you only need task creation, you can also disable the auto voice label option.",
+            )
             return False
 
     def add_task(self, task_data):
@@ -182,7 +217,10 @@ class VikunjaAPI:
             _LOGGER.error(
                 "Failed to assign user %s to task %s: %s", user_id, task_id, err
             )
-            resp = getattr(err, "response", None)
-            if resp is not None and hasattr(resp, "text"):
-                _LOGGER.error("Response content: %s", resp.text)
+            resp = self._log_response_content(err)
+            self._log_scoped_token_hint(
+                resp,
+                "assignee attachment via PUT /tasks/{taskID}/assignees",
+                "Recreate the API token and grant access for this route. On newer Vikunja versions, assignee updates may require their own scoped permission in addition to basic task creation.",
+            )
             return False

--- a/custom_components/vikunja_voice_assistant/api/vikunja_api.py
+++ b/custom_components/vikunja_voice_assistant/api/vikunja_api.py
@@ -41,7 +41,7 @@ class VikunjaAPI:
         if not self._is_invalid_token_response(response):
             return
         _LOGGER.error(
-            "Vikunja rejected %s with a route-specific token error. Scoped API tokens were tightened in Vikunja 2.3.0 and now match both HTTP method and path. %s",
+            "Vikunja rejected %s with an invalid-token response. If you're using a scoped API token, Vikunja 2.3.0 tightened token matching to both HTTP method and path. %s",
             route_description,
             remedy,
         )

--- a/custom_components/vikunja_voice_assistant/custom_sentences/en/vikunja_tasks.yaml
+++ b/custom_components/vikunja_voice_assistant/custom_sentences/en/vikunja_tasks.yaml
@@ -5,7 +5,7 @@ intents:
   VikunjaAddTask:
     data:
       - sentences:
-          - "[I | I'd | I'll | I'm | I want to | I would like to | I need to | let's | please | can you | could you] (add | ad | at | and | had | app | create | crate | great | grade | make | mate | have | set | put | do | get | dad | head | insert | schedule | fake | creates) [a | an | the | this | that | my | new | one] [new | upcoming | quick | simple | daily | weekly | rapid | urgent] (task | tasker | tusk | ask | tests | tasks | to do | to-do | todo | task for | item | thing) {task_description}"
+          - "[I | I'd | I'll | I'm | I want to | I would like to | I need to | let's | please | can you | could you] (add | ad | at | and | had | app | create | crate | great | grade | make | mate | have | set | put | do | get | dad | head | insert | schedule | fake | creates| what's) [a | an | the | this | that | my | new | one] [new | upcoming | quick | simple | daily | weekly | rapid | urgent] (task | tasker | tusk | ask | tests | tasks | to do | to-do | todo | task for | item | thing) {task_description}"
 
 lists:
   task_description:

--- a/custom_components/vikunja_voice_assistant/custom_sentences/en/vikunja_tasks.yaml
+++ b/custom_components/vikunja_voice_assistant/custom_sentences/en/vikunja_tasks.yaml
@@ -5,7 +5,7 @@ intents:
   VikunjaAddTask:
     data:
       - sentences:
-          - "[I | I'd | I'll | I'm | I want to | I would like to | I need to | let's | please | can you | could you] (add | ad | at | and | had | app | create | crate | great | grade | make | mate | have | set | put | do | get | dad | head | insert | schedule) [a | an | the | this | that | my | new | one] [new | upcoming | quick | simple | daily | weekly | rapid | urgent] (task | tasker | tusk | ask | tests | tasks | to do | to-do | todo | task for | item | thing) {task_description}"
+          - "[I | I'd | I'll | I'm | I want to | I would like to | I need to | let's | please | can you | could you] (add | ad | at | and | had | app | create | crate | great | grade | make | mate | have | set | put | do | get | dad | head | insert | schedule | fake | creates) [a | an | the | this | that | my | new | one] [new | upcoming | quick | simple | daily | weekly | rapid | urgent] (task | tasker | tusk | ask | tests | tasks | to do | to-do | todo | task for | item | thing) {task_description}"
 
 lists:
   task_description:

--- a/custom_components/vikunja_voice_assistant/manifest.json
+++ b/custom_components/vikunja_voice_assistant/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/NeoHuncho/vikunja-voice-assistant/issues",
   "requirements": ["requests", "aiohttp"],
-  "version": "2.0.0"
+  "version": "2.0.1"
 }

--- a/custom_components/vikunja_voice_assistant/manifest.json
+++ b/custom_components/vikunja_voice_assistant/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/NeoHuncho/vikunja-voice-assistant/issues",
   "requirements": ["requests", "aiohttp"],
-  "version": "2.0.1"
+  "version": "2.0.2"
 }

--- a/custom_components/vikunja_voice_assistant/strings.json
+++ b/custom_components/vikunja_voice_assistant/strings.json
@@ -6,7 +6,7 @@
         "title": "Vikunja voice assistant",
         "description": "Set up Vikunja voice assistant integration",
         "data": {
-          "vikunja_url": "Vikunja base URL (e.g. https://vikunja.example.com)",
+          "vikunja_url": "Vikunja base URL",
           "vikunja_api_key": "Vikunja API Token",
           "ai_task_entity": "AI Task entity",
           "voice_correction": "Enable speech recognition text correction (recommended)",
@@ -20,7 +20,7 @@
         "title": "Reconfigure Vikunja voice assistant",
         "description": "Update the Vikunja voice assistant integration",
         "data": {
-          "vikunja_url": "Vikunja base URL (e.g. https://vikunja.example.com)",
+          "vikunja_url": "Vikunja base URL",
           "vikunja_api_key": "Vikunja API Token",
           "ai_task_entity": "AI Task entity",
           "voice_correction": "Enable speech recognition text correction (recommended)",

--- a/custom_components/vikunja_voice_assistant/translations/ar.json
+++ b/custom_components/vikunja_voice_assistant/translations/ar.json
@@ -5,7 +5,7 @@
         "title": "مساعد الصوت Vikunja",
         "description": "إعداد تكامل مساعد الصوت لفكونجا",
         "data": {
-          "vikunja_url": "عنوان URL الأساسي لـ Vikunja (مثال https://vikunja.example.com)",
+          "vikunja_url": "عنوان URL الأساسي لـ Vikunja",
           "vikunja_api_key": "رمز واجهة برمجة تطبيقات Vikunja",
           "ai_task_entity": "كيان مهمة الذكاء الاصطناعي",
           "voice_correction": "تفعيل تصحيح نص التعرف الصوتي (مستحسن)",
@@ -19,7 +19,7 @@
         "title": "إعادة تهيئة مساعد الصوت Vikunja",
         "description": "تحديث إعدادات تكامل مساعد الصوت Vikunja",
         "data": {
-          "vikunja_url": "عنوان URL الأساسي لـ Vikunja (مثال https://vikunja.example.com)",
+          "vikunja_url": "عنوان URL الأساسي لـ Vikunja",
           "vikunja_api_key": "رمز واجهة برمجة تطبيقات Vikunja",
           "ai_task_entity": "كيان مهمة الذكاء الاصطناعي",
           "voice_correction": "تفعيل تصحيح نص التعرف الصوتي (مستحسن)",

--- a/custom_components/vikunja_voice_assistant/translations/bn.json
+++ b/custom_components/vikunja_voice_assistant/translations/bn.json
@@ -5,7 +5,7 @@
         "title": "Vikunja ভয়েস সহকারী",
         "description": "Vikunja ভয়েস সহকারী ইন্টিগ্রেশন সেটআপ করুন",
         "data": {
-          "vikunja_url": "Vikunja বেস URL (যেমন https://vikunja.example.com)",
+          "vikunja_url": "Vikunja বেস URL",
           "vikunja_api_key": "Vikunja API টোকেন",
           "ai_task_entity": "AI টাস্ক সত্তা",
           "voice_correction": "ভয়েস রিকগনিশন টেক্সট সংশোধন সক্রিয় করুন (প্রস্তাবিত)",
@@ -19,7 +19,7 @@
         "title": "Vikunja ভয়েস সহকারী পুনঃসংযোজন",
         "description": "Vikunja ভয়েস সহকারী ইন্টিগ্রেশনের কনফিগারেশন আপডেট করুন",
         "data": {
-          "vikunja_url": "Vikunja বেস URL (যেমন https://vikunja.example.com)",
+          "vikunja_url": "Vikunja বেস URL",
           "vikunja_api_key": "Vikunja API টোকেন",
           "ai_task_entity": "AI টাস্ক সত্তা",
           "voice_correction": "ভয়েস রিকগনিশন টেক্সট সংশোধন সক্রিয় করুন (প্রস্তাবিত)",

--- a/custom_components/vikunja_voice_assistant/translations/de.json
+++ b/custom_components/vikunja_voice_assistant/translations/de.json
@@ -5,7 +5,7 @@
         "title": "Vikunja Sprachassistent",
         "description": "Vikunja Sprachassistent-Integration einrichten",
         "data": {
-          "vikunja_url": "Vikunja Basis-URL (z.B. https://vikunja.example.com)",
+          "vikunja_url": "Vikunja Basis-URL",
           "vikunja_api_key": "Vikunja API-Token",
           "ai_task_entity": "AI-Task-Entität",
           "voice_correction": "Spracherkennungs-Textkorrektur aktivieren (empfohlen)",
@@ -19,7 +19,7 @@
         "title": "Vikunja Sprachassistent neu konfigurieren",
         "description": "Aktualisieren Sie die Konfiguration der Vikunja Sprachassistent-Integration",
         "data": {
-          "vikunja_url": "Vikunja Basis-URL (z.B. https://vikunja.example.com)",
+          "vikunja_url": "Vikunja Basis-URL",
           "vikunja_api_key": "Vikunja API-Token",
           "ai_task_entity": "AI-Task-Entität",
           "voice_correction": "Spracherkennungs-Textkorrektur aktivieren (empfohlen)",

--- a/custom_components/vikunja_voice_assistant/translations/en.json
+++ b/custom_components/vikunja_voice_assistant/translations/en.json
@@ -5,7 +5,7 @@
         "title": "Vikunja voice assistant",
         "description": "Set up Vikunja voice assistant integration",
         "data": {
-          "vikunja_url": "Vikunja base URL (e.g. https://vikunja.example.com)",
+          "vikunja_url": "Vikunja base URL",
           "vikunja_api_key": "Vikunja API Token",
           "ai_task_entity": "AI Task entity",
           "voice_correction": "Enable speech recognition text correction (recommended)",
@@ -19,7 +19,7 @@
         "title": "Reconfigure Vikunja voice assistant",
         "description": "Update the Vikunja voice assistant integration",
         "data": {
-          "vikunja_url": "Vikunja base URL (e.g. https://vikunja.example.com)",
+          "vikunja_url": "Vikunja base URL",
           "vikunja_api_key": "Vikunja API Token",
           "ai_task_entity": "AI Task entity",
           "voice_correction": "Enable speech recognition text correction (recommended)",

--- a/custom_components/vikunja_voice_assistant/translations/es.json
+++ b/custom_components/vikunja_voice_assistant/translations/es.json
@@ -5,7 +5,7 @@
         "title": "Asistente de voz Vikunja",
         "description": "Configura la integración del asistente de voz de Vikunja",
         "data": {
-          "vikunja_url": "URL base de Vikunja (ej. https://vikunja.example.com)",
+          "vikunja_url": "URL base de Vikunja",
           "vikunja_api_key": "Token API de Vikunja",
           "ai_task_entity": "Entidad de tarea de IA",
           "voice_correction": "Habilitar corrección de texto de reconocimiento de voz (recomendado)",
@@ -19,7 +19,7 @@
         "title": "Reconfigurar asistente de voz Vikunja",
         "description": "Actualiza la configuración de la integración del asistente de voz de Vikunja",
         "data": {
-          "vikunja_url": "URL base de Vikunja (ej. https://vikunja.example.com)",
+          "vikunja_url": "URL base de Vikunja",
           "vikunja_api_key": "Token API de Vikunja",
           "ai_task_entity": "Entidad de tarea de IA",
           "voice_correction": "Habilitar corrección de texto de reconocimiento de voz (recomendado)",

--- a/custom_components/vikunja_voice_assistant/translations/fr.json
+++ b/custom_components/vikunja_voice_assistant/translations/fr.json
@@ -5,7 +5,7 @@
         "title": "Assistant vocal Vikunja",
         "description": "Configurer l'intégration de l'assistant vocal Vikunja",
         "data": {
-          "vikunja_url": "URL de base Vikunja (ex. https://vikunja.example.com)",
+          "vikunja_url": "URL de base Vikunja",
           "vikunja_api_key": "Jeton d'API Vikunja",
           "ai_task_entity": "Entité de tâche IA",
           "voice_correction": "Activer la correction du texte de reconnaissance vocale (recommandé)",
@@ -19,7 +19,7 @@
         "title": "Reconfigurer l'assistant vocal Vikunja",
         "description": "Mettre à jour la configuration de l'intégration de l'assistant vocal Vikunja",
         "data": {
-          "vikunja_url": "URL de base Vikunja (ex. https://vikunja.example.com)",
+          "vikunja_url": "URL de base Vikunja",
           "vikunja_api_key": "Jeton d'API Vikunja",
           "ai_task_entity": "Entité de tâche IA",
           "voice_correction": "Activer la correction du texte de reconnaissance vocale (recommandé)",

--- a/custom_components/vikunja_voice_assistant/translations/hi.json
+++ b/custom_components/vikunja_voice_assistant/translations/hi.json
@@ -5,7 +5,7 @@
         "title": "Vikunja वॉइस असिस्टेंट",
         "description": "Vikunja वॉइस असिस्टेंट इंटीग्रेशन सेटअप करें",
         "data": {
-          "vikunja_url": "Vikunja बेस URL (उदा. https://vikunja.example.com)",
+          "vikunja_url": "Vikunja बेस URL",
           "vikunja_api_key": "Vikunja API टोकन",
           "ai_task_entity": "AI कार्य इकाई",
           "voice_correction": "वॉइस रिकॉग्निशन टेक्स्ट सुधार सक्षम करें (अनुशंसित)",
@@ -19,7 +19,7 @@
         "title": "Vikunja वॉइस असिस्टेंट पुनः कॉन्फ़िगर करें",
         "description": "Vikunja वॉइस असिस्टेंट इंटीग्रेशन की कॉन्फ़िगरेशन अपडेट करें",
         "data": {
-          "vikunja_url": "Vikunja बेस URL (उदा. https://vikunja.example.com)",
+          "vikunja_url": "Vikunja बेस URL",
           "vikunja_api_key": "Vikunja API टोकन",
           "ai_task_entity": "AI कार्य इकाई",
           "voice_correction": "वॉइस रिकॉग्निशन टेक्स्ट सुधार सक्षम करें (अनुशंसित)",

--- a/custom_components/vikunja_voice_assistant/translations/id.json
+++ b/custom_components/vikunja_voice_assistant/translations/id.json
@@ -5,7 +5,7 @@
         "title": "Asisten suara Vikunja",
         "description": "Atur integrasi asisten suara Vikunja",
         "data": {
-          "vikunja_url": "URL dasar Vikunja (mis. https://vikunja.example.com)",
+          "vikunja_url": "URL dasar Vikunja",
           "vikunja_api_key": "Token API Vikunja",
           "ai_task_entity": "Entitas tugas AI",
           "voice_correction": "Aktifkan koreksi teks pengenalan suara (disarankan)",
@@ -19,7 +19,7 @@
         "title": "Konfigurasi ulang asisten suara Vikunja",
         "description": "Perbarui konfigurasi integrasi asisten suara Vikunja",
         "data": {
-          "vikunja_url": "URL dasar Vikunja (mis. https://vikunja.example.com)",
+          "vikunja_url": "URL dasar Vikunja",
           "vikunja_api_key": "Token API Vikunja",
           "ai_task_entity": "Entitas tugas AI",
           "voice_correction": "Aktifkan koreksi teks pengenalan suara (disarankan)",

--- a/custom_components/vikunja_voice_assistant/translations/pt.json
+++ b/custom_components/vikunja_voice_assistant/translations/pt.json
@@ -5,7 +5,7 @@
         "title": "Assistente de voz Vikunja",
         "description": "Configurar a integração do assistente de voz Vikunja",
         "data": {
-          "vikunja_url": "URL base do Vikunja (ex. https://vikunja.example.com)",
+          "vikunja_url": "URL base do Vikunja",
           "vikunja_api_key": "Token de API do Vikunja",
           "ai_task_entity": "Entidade de tarefa de IA",
           "voice_correction": "Ativar correção de texto de reconhecimento de voz (recomendado)",
@@ -19,7 +19,7 @@
         "title": "Reconfigurar assistente de voz Vikunja",
         "description": "Atualize a configuração da integração do assistente de voz Vikunja",
         "data": {
-          "vikunja_url": "URL base do Vikunja (ex. https://vikunja.example.com)",
+          "vikunja_url": "URL base do Vikunja",
           "vikunja_api_key": "Token de API do Vikunja",
           "ai_task_entity": "Entidade de tarefa de IA",
           "voice_correction": "Ativar correção de texto de reconhecimento de voz (recomendado)",

--- a/custom_components/vikunja_voice_assistant/translations/ru.json
+++ b/custom_components/vikunja_voice_assistant/translations/ru.json
@@ -5,7 +5,7 @@
         "title": "Голосовой помощник Vikunja",
         "description": "Настройте интеграцию голосового помощника Vikunja",
         "data": {
-          "vikunja_url": "Базовый URL Vikunja (пример https://vikunja.example.com)",
+          "vikunja_url": "Базовый URL Vikunja",
           "vikunja_api_key": "API токен Vikunja",
           "ai_task_entity": "Сущность AI Task",
           "voice_correction": "Включить исправление текста распознавания речи (рекомендуется)",
@@ -19,7 +19,7 @@
         "title": "Перенастройка голосового помощника Vikunja",
         "description": "Обновите конфигурацию интеграции голосового помощника Vikunja",
         "data": {
-          "vikunja_url": "Базовый URL Vikunja (пример https://vikunja.example.com)",
+          "vikunja_url": "Базовый URL Vikunja",
           "vikunja_api_key": "API токен Vikunja",
           "ai_task_entity": "Сущность AI Task",
           "voice_correction": "Включить исправление текста распознавания речи (рекомендуется)",

--- a/custom_components/vikunja_voice_assistant/translations/zh-Hans.json
+++ b/custom_components/vikunja_voice_assistant/translations/zh-Hans.json
@@ -5,7 +5,7 @@
         "title": "Vikunja 语音助手",
         "description": "设置 Vikunja 语音助手集成",
         "data": {
-          "vikunja_url": "Vikunja 基础 URL (例如 https://vikunja.example.com)",
+          "vikunja_url": "Vikunja 基础 URL",
             "vikunja_api_key": "Vikunja API 令牌",
             "ai_task_entity": "AI 任务实体",
             "voice_correction": "启用语音识别文本纠正 (推荐)",
@@ -19,7 +19,7 @@
         "title": "重新配置 Vikunja 语音助手",
         "description": "更新 Vikunja 语音助手集成配置",
         "data": {
-          "vikunja_url": "Vikunja 基础 URL (例如 https://vikunja.example.com)",
+          "vikunja_url": "Vikunja 基础 URL",
           "vikunja_api_key": "Vikunja API 令牌",
           "ai_task_entity": "AI 任务实体",
           "voice_correction": "启用语音识别文本纠正 (推荐)",

--- a/tests/test_vikunja_api.py
+++ b/tests/test_vikunja_api.py
@@ -2,6 +2,7 @@ import logging
 
 import requests
 
+from custom_components.vikunja_voice_assistant.api import vikunja_api as vikunja_api_module
 from custom_components.vikunja_voice_assistant.api.vikunja_api import VikunjaAPI
 
 
@@ -22,17 +23,32 @@ class FakeUnauthorizedResponse:
         raise requests.exceptions.HTTPError(response=self)
 
 
-def test_add_label_to_task_logs_scoped_token_hint(monkeypatch, caplog):
-    api = VikunjaAPI("https://example.com/api/v1", "token")
-
+def _patch_unauthorized_put(monkeypatch):
     def fake_put(*args, **kwargs):
         return FakeUnauthorizedResponse()
 
-    monkeypatch.setattr(requests, "put", fake_put)
+    monkeypatch.setattr(vikunja_api_module.requests, "put", fake_put)
+
+
+def test_add_label_to_task_logs_scoped_token_hint(monkeypatch, caplog):
+    api = VikunjaAPI("https://example.com/api/v1", "token")
+    _patch_unauthorized_put(monkeypatch)
 
     with caplog.at_level(logging.ERROR):
         ok = api.add_label_to_task(4366, 44)
 
     assert ok is False
-    assert "Scoped API tokens were tightened in Vikunja 2.3.0" in caplog.text
+    assert "If you're using a scoped API token" in caplog.text
     assert "task-update scope in addition to label read/create permissions" in caplog.text
+
+
+def test_assign_user_to_task_logs_scoped_token_hint(monkeypatch, caplog):
+    api = VikunjaAPI("https://example.com/api/v1", "token")
+    _patch_unauthorized_put(monkeypatch)
+
+    with caplog.at_level(logging.ERROR):
+        ok = api.assign_user_to_task(4366, 44)
+
+    assert ok is False
+    assert "If you're using a scoped API token" in caplog.text
+    assert "assignee updates may require their own scoped permission" in caplog.text

--- a/tests/test_vikunja_api.py
+++ b/tests/test_vikunja_api.py
@@ -1,0 +1,38 @@
+import logging
+
+import requests
+
+from custom_components.vikunja_voice_assistant.api.vikunja_api import VikunjaAPI
+
+
+class FakeUnauthorizedResponse:
+    status_code = 401
+    text = (
+        '{"code":11,"message":"missing, malformed, expired or otherwise invalid '
+        'token provided"}'
+    )
+
+    def json(self):
+        return {
+            "code": 11,
+            "message": "missing, malformed, expired or otherwise invalid token provided",
+        }
+
+    def raise_for_status(self):
+        raise requests.exceptions.HTTPError(response=self)
+
+
+def test_add_label_to_task_logs_scoped_token_hint(monkeypatch, caplog):
+    api = VikunjaAPI("https://example.com/api/v1", "token")
+
+    def fake_put(*args, **kwargs):
+        return FakeUnauthorizedResponse()
+
+    monkeypatch.setattr(requests, "put", fake_put)
+
+    with caplog.at_level(logging.ERROR):
+        ok = api.add_label_to_task(4366, 44)
+
+    assert ok is False
+    assert "Scoped API tokens were tightened in Vikunja 2.3.0" in caplog.text
+    assert "task-update scope in addition to label read/create permissions" in caplog.text


### PR DESCRIPTION
## Summary
- broaden the English task-creation sentence variants for better voice recognition
- document Vikunja 2.3.0 scoped-token permission requirements and improve invalid-token guidance for label and assignee update failures
- remove literal example URLs from config translation labels so Home Assistant validation passes

## Type
- [ ] Feature
- [x] Fix
- [ ] Refactor / Cleanup
- [x] Docs

## Checklist
- [x] Minimal logging (no leftover debug prints)
- [x] Updated README / docs if behavior changed
- [ ] Tested locally in Home Assistant

## Linked Issues
None

## Screens / Video (REQUIRED)
N/A - no UI changes

## Notes for Reviewer
- Follow-up work for this PR removes literal example URLs from translation labels to fix the failing `validate` check.
- Copilot review feedback is addressed by making the scoped-token hint conditional, adding an assignee-path regression test, and patching the module-local `requests.put` reference in tests.
- Local validation run: `python3 -m pytest tests/test_vikunja_api.py -q` and `python3 scripts/check_translations.py`.