### PR TITLE
Fix duplicate auto voice labels

### DIFF
--- a/custom_components/vikunja_voice_assistant/api/vikunja_api.py
+++ b/custom_components/vikunja_voice_assistant/api/vikunja_api.py
@@ -101,19 +101,67 @@ class VikunjaAPI:
                 _LOGGER.error("Response content: %s", resp.text)
             return []
 
-    def get_labels(self):
+    @staticmethod
+    def _pagination_total_pages(response):
         try:
-            response = requests.get(
-                f"{self.url}/labels", headers=self.headers, timeout=30
-            )
-            response.raise_for_status()
-            return response.json()
-        except requests.exceptions.RequestException as err:
-            _LOGGER.error("Failed to get labels: %s", err)
-            resp = getattr(err, "response", None)
-            if resp is not None and hasattr(resp, "text"):
-                _LOGGER.error("Response content: %s", resp.text)
-            return []
+            return int(response.headers.get("x-pagination-total-pages", ""))
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _normalize_label_title(title):
+        return str(title or "").strip().casefold()
+
+    @classmethod
+    def find_label_by_title(cls, labels, label_name):
+        """Return the first label with an exact title match."""
+        normalized_name = cls._normalize_label_title(label_name)
+        for label in labels or []:
+            if not isinstance(label, dict):
+                continue
+            if cls._normalize_label_title(label.get("title")) == normalized_name:
+                return label
+        return None
+
+    def get_labels(self, search=None):
+        labels = []
+        page = 1
+        per_page = 100
+        while True:
+            params = {"page": page, "per_page": per_page}
+            if search:
+                params["s"] = search
+            try:
+                response = requests.get(
+                    f"{self.url}/labels",
+                    headers=self.headers,
+                    params=params,
+                    timeout=30,
+                )
+                response.raise_for_status()
+                data = response.json()
+            except requests.exceptions.RequestException as err:
+                _LOGGER.error("Failed to get labels: %s", err)
+                resp = getattr(err, "response", None)
+                if resp is not None and hasattr(resp, "text"):
+                    _LOGGER.error("Response content: %s", resp.text)
+                return labels
+
+            if not isinstance(data, list):
+                return labels
+
+            labels.extend(data)
+            total_pages = self._pagination_total_pages(response)
+            if total_pages is not None:
+                if page >= total_pages:
+                    break
+            elif len(data) < per_page:
+                break
+            page += 1
+        return labels
+
+    def get_label_by_title(self, label_name):
+        return self.find_label_by_title(self.get_labels(search=label_name), label_name)
 
     def create_label(self, label_name):
         """Create a new label with a random hex color."""

--- a/custom_components/vikunja_voice_assistant/task_handler.py
+++ b/custom_components/vikunja_voice_assistant/task_handler.py
@@ -28,6 +28,28 @@ _LOGGER = logging.getLogger(__name__)
 ## NOTE: `_friendly_due_phrase` removed; using `friendly_due_phrase` from response_formatter.
 
 
+def _append_label_if_missing(labels, label):
+    if not isinstance(labels, list) or not isinstance(label, dict):
+        return
+    label_id = label.get("id")
+    if label_id is not None and any(
+        isinstance(existing, dict) and existing.get("id") == label_id
+        for existing in labels
+    ):
+        return
+    labels.append(label)
+
+
+def _find_label_by_title(labels, label_name):
+    normalized_name = str(label_name or "").strip().casefold()
+    for label in labels or []:
+        if not isinstance(label, dict):
+            continue
+        if str(label.get("title") or "").strip().casefold() == normalized_name:
+            return label
+    return None
+
+
 async def process_task(
     hass, task_description: str, user_cache_users: List[Dict[str, Any]]
 ):
@@ -59,16 +81,21 @@ async def process_task(
     voice_label_id = None
     if auto_voice_label:
         try:
-            for lbl in labels or []:
-                if isinstance(lbl, dict) and lbl.get("title", "").lower() == "voice":
-                    voice_label_id = lbl.get("id")
-                    break
+            voice_label = _find_label_by_title(labels, "voice")
+            if voice_label is None:
+                voice_label = await hass.async_add_executor_job(
+                    vikunja_api.get_label_by_title, "voice"
+                )
+                _append_label_if_missing(labels, voice_label)
+            if voice_label:
+                voice_label_id = voice_label.get("id")
             if voice_label_id is None:
                 voice_label = await hass.async_add_executor_job(
                     vikunja_api.create_label, "voice"
                 )
                 if voice_label:
                     voice_label_id = voice_label.get("id")
+                    _append_label_if_missing(labels, voice_label)
         except Exception as label_err:  # noqa: BLE001
             _LOGGER.error("Could not ensure 'voice' label exists: %s", label_err)
 

--- a/tests/test_process_task.py
+++ b/tests/test_process_task.py
@@ -30,8 +30,11 @@ class FakeVikunjaAPI:
     def __init__(self, url, key):  # noqa: D401
         self._projects = []
         self._labels = []
+        self._label_search_results = {}
         self._tasks_created = []
         self._assignments = []
+        self._created_labels = []
+        self._attached_labels = []
 
     def _set_projects(self, projects):
         self._projects = projects
@@ -39,13 +42,20 @@ class FakeVikunjaAPI:
     def _set_labels(self, labels):
         self._labels = labels
 
+    def _set_label_search_result(self, label_name, label):
+        self._label_search_results[label_name] = label
+
     def get_projects(self):
         return self._projects
 
     def get_labels(self):
         return self._labels
 
+    def get_label_by_title(self, name):
+        return self._label_search_results.get(name)
+
     def create_label(self, name):
+        self._created_labels.append(name)
         return {"id": 999, "title": name}
 
     def add_task(self, task_data):
@@ -54,6 +64,7 @@ class FakeVikunjaAPI:
         return task
 
     def add_label_to_task(self, task_id, label_id):
+        self._attached_labels.append((task_id, label_id))
         return True
 
     def assign_user_to_task(self, task_id, user_id):
@@ -159,6 +170,25 @@ def test_process_task_with_assignee(patch_apis):
     assert ok is True
     assert "assigned to alice" in msg
     assert fake_vikunja._assignments == [(123, 7)]
+
+
+def test_process_task_reuses_voice_label_found_by_search(patch_apis):
+    fake_vikunja, fake_llm = patch_apis
+    fake_vikunja._set_projects([])
+    fake_vikunja._set_labels([{"id": 7, "title": "other"}])
+    fake_vikunja._set_label_search_result("voice", {"id": 42, "title": "voice"})
+    fake_llm.set_response({"title": "Buy milk", "project_id": 1})
+    hass = FakeHass(
+        base_config(CONF_AUTO_VOICE_LABEL=True, CONF_DETAILED_RESPONSE=False)
+    )
+
+    ok, msg, title = asyncio.run(process_task(hass, "Buy milk", []))
+
+    assert ok is True
+    assert title == "Buy milk"
+    assert msg == "Successfully added task: Buy milk"
+    assert fake_vikunja._created_labels == []
+    assert fake_vikunja._attached_labels == [(123, 42)]
 
 
 def test_process_task_llm_failure(patch_apis, monkeypatch):

--- a/tests/test_vikunja_api.py
+++ b/tests/test_vikunja_api.py
@@ -23,6 +23,19 @@ class FakeUnauthorizedResponse:
         raise requests.exceptions.HTTPError(response=self)
 
 
+class FakeLabelResponse:
+    def __init__(self, data, total_pages=1):
+        self._data = data
+        self.headers = {"x-pagination-total-pages": str(total_pages)}
+        self.text = ""
+
+    def json(self):
+        return self._data
+
+    def raise_for_status(self):
+        return None
+
+
 def _patch_unauthorized_put(monkeypatch):
     def fake_put(*args, **kwargs):
         return FakeUnauthorizedResponse()
@@ -52,3 +65,40 @@ def test_assign_user_to_task_logs_scoped_token_hint(monkeypatch, caplog):
     assert ok is False
     assert "If you're using a scoped API token" in caplog.text
     assert "assignee updates may require their own scoped permission" in caplog.text
+
+
+def test_get_labels_fetches_all_pages(monkeypatch):
+    api = VikunjaAPI("https://example.com/api/v1", "token")
+    calls = []
+
+    def fake_get(*args, **kwargs):
+        params = kwargs["params"]
+        calls.append(params.copy())
+        if params["page"] == 1:
+            return FakeLabelResponse([{"id": 1, "title": "first"}], total_pages=2)
+        return FakeLabelResponse([{"id": 2, "title": "voice"}], total_pages=2)
+
+    monkeypatch.setattr(vikunja_api_module.requests, "get", fake_get)
+
+    assert api.get_labels() == [
+        {"id": 1, "title": "first"},
+        {"id": 2, "title": "voice"},
+    ]
+    assert calls == [
+        {"page": 1, "per_page": 100},
+        {"page": 2, "per_page": 100},
+    ]
+
+
+def test_get_label_by_title_searches_and_uses_exact_match(monkeypatch):
+    api = VikunjaAPI("https://example.com/api/v1", "token")
+
+    def fake_get(*args, **kwargs):
+        assert kwargs["params"]["s"] == "voice"
+        return FakeLabelResponse(
+            [{"id": 1, "title": "voicemail"}, {"id": 2, "title": " Voice "}],
+        )
+
+    monkeypatch.setattr(vikunja_api_module.requests, "get", fake_get)
+
+    assert api.get_label_by_title("voice") == {"id": 2, "title": " Voice "}


### PR DESCRIPTION
## Summary
- Fetch all pages from Vikunja `GET /labels` so existing labels are not missed after pagination.
- Search for an exact `voice` label before creating one, preventing new duplicates when the label is beyond page 1.
- Keep the found or created label in the local label list so the LLM prompt and attachment flow use the same label data.

## Testing
- `python3 -m pytest`

## Notes
This stops future duplicate `voice` labels from being created. Existing duplicate labels still need to be cleaned up manually in Vikunja.